### PR TITLE
Added tick word to access word's address directly

### DIFF
--- a/lib/src/expr.rs
+++ b/lib/src/expr.rs
@@ -2,6 +2,8 @@ use super::object::*;
 use super::token::*;
 use super::error::*;
 
+/// An expression is an action that returns
+/// an internal compilation object
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     Literal(LiteralExpr),

--- a/lib/src/interpreter.rs
+++ b/lib/src/interpreter.rs
@@ -201,6 +201,11 @@ impl StmtVisitor for Interpreter {
     fn visit_asm(&mut self, _stmt: &mut AsmStmt) -> BoxResult<Compiled> {
         Ok(Compiled::new(vec![]))
     }
+
+    fn visit_tick(&mut self, _stmt: &mut TickStmt) -> BoxResult<Compiled> {
+        // TODO interpreter needs to support tick
+        Ok(Compiled::new(vec![]))
+    }
 }
 
 impl ExprVisitor for Interpreter {

--- a/lib/src/parser.rs
+++ b/lib/src/parser.rs
@@ -65,6 +65,8 @@ impl Parser {
             return self.mod_stmt();
         } else if self.is_match(vec![TokenType::Use]) {
             return self.use_stmt();
+        } else if self.is_match(vec![TokenType::Tick]) {
+            return self.tick_stmt();
         } else {
             // default case
             let expr = match self.expr() {
@@ -157,6 +159,12 @@ impl Parser {
     fn loop_stmt(&mut self) -> BoxResult<Stmt> {
         let loop_body = Box::new(self.block_stmt(TokenType::Until)?);
         return Ok(Stmt::Loop(LoopStmt::new(loop_body, self.previous().clone())));
+    }
+
+    fn tick_stmt(&mut self) -> BoxResult<Stmt> {
+        let token = self.previous().clone();
+        let word = self.expr()?;
+        return Ok(Stmt::Tick(TickStmt::new(word, token)));
     }
 
     fn expr(&mut self) -> BoxResult<Expr> {

--- a/lib/src/stmt.rs
+++ b/lib/src/stmt.rs
@@ -4,6 +4,8 @@ use super::error::*;
 use super::expr::*;
 use std::str;
 
+/// a statement instruction the compiler to
+/// perform an action and returns the resulting code
 #[derive(Clone)]
 pub struct Compiled {
     pub data: Vec<u8>
@@ -44,7 +46,8 @@ pub enum Stmt {
     Loop(LoopStmt),
     Use(UseStmt),
     Asm(AsmStmt),
-    Mod(ModStmt)
+    Mod(ModStmt),
+    Tick(TickStmt)
 }
 
 impl StmtNode for Stmt {
@@ -57,7 +60,8 @@ impl StmtNode for Stmt {
             Self::Loop(loopstmt) => loopstmt.accept(visitor),
             Self::Use(usestmt) => usestmt.accept(visitor),
             Self::Mod(modstmt) => modstmt.accept(visitor),
-            Self::Asm(asmstmt) => asmstmt.accept(visitor)
+            Self::Asm(asmstmt) => asmstmt.accept(visitor),
+            Self::Tick(tickstmt) => tickstmt.accept(visitor)
         }
     }
 }
@@ -79,6 +83,7 @@ pub trait StmtVisitor {
     fn visit_use(&mut self, stmt: &mut UseStmt) -> BoxResult<Compiled>;
     fn visit_mod(&mut self, stmt: &mut ModStmt) -> BoxResult<Compiled>;
     fn visit_asm(&mut self, stmt: &mut AsmStmt) -> BoxResult<Compiled>;
+    fn visit_tick(&mut self, stmt: &mut TickStmt) -> BoxResult<Compiled>;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -287,5 +292,30 @@ impl StmtNode for ModStmt {
 
     fn token(&self) -> Token {
         self.name.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TickStmt {
+    pub token: Token,
+    pub word: Expr
+}
+
+impl TickStmt {
+    pub fn new(word: Expr, token: Token) -> Self {
+        Self {
+            word,
+            token
+        }
+    }
+}
+
+impl StmtNode for TickStmt {
+    fn accept(&mut self, visitor: &mut dyn StmtVisitor) -> BoxResult<Compiled> {
+        return visitor.visit_tick(self);
+    }
+
+    fn token(&self) -> Token {
+        self.token.clone()
     }
 }

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -27,6 +27,7 @@ pub enum TokenType {
     Asm, // :asm "<asm code>"
     Use, // :use "file"
     Mod, // :mod module_name
+    Tick, // used to find definition of word
 
     EndOfFile,
 }


### PR DESCRIPTION
- New keyword '
- New compile-time word __tick to handle the call 
- Interpreter does not support ' yet. See #15 